### PR TITLE
release: v1.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [1.1.1] - 2026-08-03
+
+### Fixed
+
+- **Server-connection banner no longer covers the phone's notification bar.** The red "server unreachable" banner sat edge-to-edge at viewport top:0, which on Android slid it up over the status bar / clock / hamburger. Now floats as a rounded card below the status bar and the app's compact header, matching NutriTrace.
+
+---
+
 ## [1.1.0] - 2026-08-02
 
 > **⚠ Upgrade note.** The Android app identifier change (`app.cooktrace.local`, see "Changed" below) invalidates the WebView's cached auth cookie. Server-connected Android users will need to re-enter their server URL and sign back in once after upgrading; standalone Android users lose their theme / accent / display prefs but keep all recipe, pantry, diary, and shopping data (that lives in local SQLite, unaffected). PWA / browser users are not affected.

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -19,8 +19,8 @@ android {
         applicationId "com.cooktrace.app"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 99
-        versionName "1.1.0"
+        versionCode 100
+        versionName "1.1.1"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         aaptOptions {
              // Files and dirs to omit from the packaged assets dir, modified to accommodate modern web apps.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cooktrace",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cooktrace-api",
-  "version": "1.1.0-dev09",
+  "version": "1.1.1",
   "type": "module",
   "scripts": {
     "start": "node index.js",

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -658,43 +658,49 @@
      frame) doesn't get clipped on narrow phones. */
   .sync-bar-msg { flex: 1; min-width: 0; white-space: normal; word-break: break-word; }
 
-  /* Smart connection banner (fixed at the top when sync fails or the
-     server is unreachable). Wider than the compact .sync-bar because it
-     carries title + detail + Retry + Dismiss. Mirrors NT's banner. */
+  /* Smart connection banner. Ported from NT so it sits BELOW the
+     device status bar and the app's compact header instead of covering
+     the clock / hamburger on Android. */
   .sync-connection-banner {
-    position: fixed; top: 0; left: 0; right: 0; z-index: 210;
-    display: flex; align-items: flex-start; gap: 10px;
-    padding: 10px 14px;
-    background: color-mix(in srgb, var(--error, #ef4444) 10%, var(--bg));
-    color: var(--text-1);
-    border-bottom: 1px solid color-mix(in srgb, var(--error, #ef4444) 25%, transparent);
-    font-size: 13px;
-    box-shadow: 0 2px 12px rgba(0, 0, 0, 0.15);
+    position: fixed;
+    top: calc(var(--safe-top) + 60px);
+    left: calc(var(--sidebar-w, 0px) + 12px);
+    right: 12px;
+    z-index: 250;
+    display: flex; align-items: center; gap: 10px;
+    padding: 10px 12px;
+    color: var(--error, #ef4444);
+    background: color-mix(in srgb, var(--error, #ef4444) 8%, var(--surface-2));
+    border: 1px solid color-mix(in srgb, var(--error, #ef4444) 25%, var(--border));
+    border-radius: var(--radius-lg);
+    box-shadow: var(--shadow-lg);
+    font-size: 12px;
+    font-weight: 500;
+    transition: left 0.25s ease;
   }
   .sync-banner-icon {
-    color: var(--error, #ef4444);
-    font-size: 20px;
-    flex-shrink: 0;
-    margin-top: 1px;
+    flex: 0 0 auto;
+    font-size: 18px;
   }
-  .sync-banner-copy { flex: 1; min-width: 0; display: flex; flex-direction: column; gap: 2px; }
-  .sync-banner-title { font-weight: 600; }
-  .sync-banner-detail { color: var(--text-2); font-size: 12px; line-height: 1.4; word-break: break-word; }
+  .sync-banner-copy {
+    min-width: 0; flex: 1;
+    display: flex; flex-direction: column; gap: 2px;
+    line-height: 1.35;
+  }
+  .sync-banner-title { font-size: 13px; font-weight: 600; }
+  .sync-banner-detail { color: var(--text-2); font-weight: 400; }
   .sync-banner-btn {
-    background: transparent; color: var(--accent);
-    border: 1px solid color-mix(in srgb, var(--accent) 30%, transparent);
-    border-radius: 6px;
-    font-size: 12px; font-weight: 600;
-    padding: 6px 10px; cursor: pointer;
-    flex-shrink: 0;
+    flex: 0 0 auto;
+    border: 0;
+    color: var(--error, #ef4444);
+    background: transparent;
+    font: inherit; font-weight: 600;
+    cursor: pointer;
   }
-  .sync-banner-btn:hover:not(:disabled) { background: color-mix(in srgb, var(--accent) 12%, transparent); }
-  .sync-banner-btn:disabled { opacity: 0.6; cursor: not-allowed; }
+  .sync-banner-btn:disabled { opacity: 0.6; cursor: default; }
   .sync-banner-dismiss {
-    border: none;
-    color: var(--text-2);
-    padding: 4px;
-    display: inline-flex; align-items: center; justify-content: center;
+    display: flex; align-items: center;
+    padding: 2px;
   }
   .sync-banner-dismiss .material-symbols-rounded { font-size: 18px; }
 

--- a/src/lib/version.js
+++ b/src/lib/version.js
@@ -1,1 +1,1 @@
-export const APP_VERSION = 'v1.1.0';
+export const APP_VERSION = 'v1.1.1';


### PR DESCRIPTION
Patch release: server-connection banner status-bar fix (Android).

The red "server unreachable" banner sat at viewport top:0 and slid up over the phone's status bar / clock / hamburger on Android. Now floats as a rounded card below the status bar and the compact header, matching NutriTrace.

Also folds v1.1.0-dev09 -> v1.1.1 version bumps across package.json, server/package.json, src/lib/version.js, and android/app/build.gradle.

See CHANGELOG for the v1.1.1 entry.