### PR TITLE
ci: publish to Docker Hub alongside GHCR

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,4 +1,4 @@
-name: Build & Push to GHCR
+name: Build & Push
 
 on:
   push:
@@ -35,17 +35,27 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      # Derive tags from the ref:
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      # Derive tags from the ref, mirrored to both registries:
       #   semver tag v1.2.3 → :1.2.3, :1.2, :1
       #   push to main      → :latest, :main, :sha-<shortsha>
       #   push to dev       → :dev, :sha-<shortsha>
       # Users pin :dev for the leading edge, :latest for stable
-      # releases, or :1.0 for auto-patch within a minor.
+      # releases, or :1.0 for auto-patch within a minor. Same tag set
+      # exists at both ghcr.io/traceapps/cooktrace and traceapps/cooktrace
+      # so users can pick either registry.
       - name: Docker metadata
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ghcr.io/traceapps/cooktrace
+          images: |
+            ghcr.io/traceapps/cooktrace
+            traceapps/cooktrace
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}


### PR DESCRIPTION
Enables dual-registry publishing. Every push to main and dev, every semver tag, now publishes to both:

- **Primary:** `ghcr.io/traceapps/cooktrace` (source of truth)
- **Mirror:** `traceapps/cooktrace` on Docker Hub (discoverability + pull-count visibility)

Same tag set on both registries. Users can pick either. Verified end-to-end on dev at 99a2cfc (workflow run 30874700421). Doc-only in the sense of infrastructure config, no app code change.