### PR TITLE
ci: drop :main + :sha-* tags (keep semver + :latest + :dev)

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -43,12 +43,17 @@ jobs:
 
       # Derive tags from the ref, mirrored to both registries:
       #   semver tag v1.2.3 → :1.2.3, :1.2, :1
-      #   push to main      → :latest, :main, :sha-<shortsha>
+      #   push to main      → :latest, :sha-<shortsha>
       #   push to dev       → :dev, :sha-<shortsha>
       # Users pin :dev for the leading edge, :latest for stable
       # releases, or :1.0 for auto-patch within a minor. Same tag set
-      # exists at both ghcr.io/traceapps/cooktrace and traceapps/cooktrace
-      # so users can pick either registry.
+      # exists at both ghcr.io/traceapps/cooktrace (primary) and
+      # traceapps/cooktrace on Docker Hub (discoverability mirror).
+      #
+      # `:main` intentionally not emitted — it would be identical to
+      # `:latest` in this workflow (both fire on every main push), so
+      # `:latest` is the only stable branch tag. `type=ref,event=branch`
+      # is gated to the dev branch so it still emits `:dev` on dev pushes.
       - name: Docker metadata
         id: meta
         uses: docker/metadata-action@v5
@@ -61,7 +66,7 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
             type=raw,value=latest,enable={{is_default_branch}}
-            type=ref,event=branch
+            type=ref,event=branch,enable=${{ github.ref == 'refs/heads/dev' }}
             type=sha
 
       - name: Build and push

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -42,18 +42,21 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       # Derive tags from the ref, mirrored to both registries:
-      #   semver tag v1.2.3 → :1.2.3, :1.2, :1
-      #   push to main      → :latest, :sha-<shortsha>
-      #   push to dev       → :dev, :sha-<shortsha>
+      #   semver tag v1.2.3 → :1.2.3, :1.2, :1, :latest
+      #   push to main      → :latest
+      #   push to dev       → :dev
       # Users pin :dev for the leading edge, :latest for stable
       # releases, or :1.0 for auto-patch within a minor. Same tag set
       # exists at both ghcr.io/traceapps/cooktrace (primary) and
       # traceapps/cooktrace on Docker Hub (discoverability mirror).
       #
-      # `:main` intentionally not emitted — it would be identical to
-      # `:latest` in this workflow (both fire on every main push), so
-      # `:latest` is the only stable branch tag. `type=ref,event=branch`
-      # is gated to the dev branch so it still emits `:dev` on dev pushes.
+      # `:main` and `:sha-*` intentionally not emitted:
+      #   - `:main` would be identical to `:latest` (both fire on every
+      #     main push) — redundant.
+      #   - `:sha-*` per-commit tags accumulate fast on a busy dev branch
+      #     and clutter the registry tag list — reproducibility for
+      #     stable is covered by `:1.2.3` semver pins, and dev-side
+      #     reproducibility can use manifest digests instead.
       - name: Docker metadata
         id: meta
         uses: docker/metadata-action@v5
@@ -67,7 +70,6 @@ jobs:
             type=semver,pattern={{major}}
             type=raw,value=latest,enable={{is_default_branch}}
             type=ref,event=branch,enable=${{ github.ref == 'refs/heads/dev' }}
-            type=sha
 
       - name: Build and push
         uses: docker/build-push-action@v5


### PR DESCRIPTION
Follow-up to the Docker Hub wiring landed in #33. Cleans up the tag set on both registries:

- Drops `:main` — identical to `:latest` in this workflow, redundant.
- Drops `:sha-*` per-commit tags — accumulate fast, add clutter, semver + digest already cover reproducibility.

Final tag set:
- `:1.2.3`, `:1.2`, `:1` — semver pins from tag pushes
- `:latest` — current main HEAD
- `:dev` — current dev branch tip

Applies to both `ghcr.io/traceapps/cooktrace` and `traceapps/cooktrace`.